### PR TITLE
docs: Fix inject example

### DIFF
--- a/inject/README.md
+++ b/inject/README.md
@@ -2,7 +2,7 @@
 
 ### 1.1 Build KoviD
 
-        cd ../ && PROCNAME=kovid make && make strip && cd -
+        cd ../ && PROCNAME=kv make && make strip && cd -
 
 ## 2 Build payload
 


### PR DESCRIPTION
'kovid' as PROCNAME is misleading because it is
not allowed by the rootkit.