### PR TITLE
Harmonize ftrace_ops flag usage around Linux 5.11

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -978,7 +978,8 @@ static int m_proc_dointvec(struct ctl_table *table, int write, void *buffer,
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
-#define FTRACE_OPS_FL_RECURSION FTRACE_OPS_FL_RECURSION_SAFE
+// Recursion test is enabled by default before Linux 5.11
+#define FTRACE_OPS_FL_RECURSION 0
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)


### PR DESCRIPTION
Before Linux 5.11, a recursion test wrapper for callback is enabled by default. `FTRACE_OPS_FL_RECURSION_SAFE` flag is for disabling this wrapper. Since Linux 5.11, this is disabled by default and `FTRACE_OPS_FL_RECURSION` is used for enabling this test.

This pull request resolves this semantic inconsistency and makes sure that recursion test is always enabled.